### PR TITLE
Fixed an NPE when Doxygen generated directory did not have a parent

### DIFF
--- a/src/main/java/hudson/plugins/doxygen/DoxygenDirectoryParser.java
+++ b/src/main/java/hudson/plugins/doxygen/DoxygenDirectoryParser.java
@@ -147,13 +147,7 @@ public class DoxygenDirectoryParser implements FilePath.FileCallable<FilePath>, 
         }
 
         final String finalComputedDoxygenDir = doxyGenDir.replace('\\', '/');
-
-        Boolean absolute = false;
-        absolute = base.act(new FilePath.FileCallable<Boolean>() {
-            public Boolean invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
-                return new File(finalComputedDoxygenDir).getParentFile().exists();
-            }
-        });
+        Boolean absolute = isDirectoryAbsolute(base, finalComputedDoxygenDir);
 
         FilePath result;
         if (absolute) {
@@ -169,6 +163,27 @@ public class DoxygenDirectoryParser implements FilePath.FileCallable<FilePath>, 
 
         return result;
     }
+
+	protected Boolean isDirectoryAbsolute(FilePath base,
+			final String finalComputedDoxygenDir) throws IOException,
+			InterruptedException {
+		Boolean absolute = false;
+		absolute = base.act(new FilePath.FileCallable<Boolean>() {
+			public Boolean invoke(File f, VirtualChannel channel)
+					throws IOException, InterruptedException {
+				
+				File parentFile = new File(finalComputedDoxygenDir).getParentFile();
+				if (parentFile == null) {
+					// A computed directory with no parent will return null.
+					// Guard against a NullPointerException
+					return false;
+				}
+				
+				return parentFile.exists();
+			}
+		});
+		return absolute;
+	}
 
     /**
      * Load the Doxyfile Doxygen file in memory

--- a/src/test/java/hudson/plugins/doxygen/DoxygenArchiverTest.java
+++ b/src/test/java/hudson/plugins/doxygen/DoxygenArchiverTest.java
@@ -21,6 +21,7 @@ import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
  
@@ -190,4 +191,16 @@ public class DoxygenArchiverTest extends AbstractWorkspaceTest {
         context.assertIsSatisfied();
     }    
     
+    @Test
+    public void pathIsRelativeWhenNoParent() throws Exception {
+    	// Arrange
+    	DoxygenDirectoryParser parser = new DoxygenDirectoryParser(DoxygenArchiverDescriptor.DOXYGEN_DOXYFILE_PUBLISHTYPE, "Doxyfile", "");
+    	
+    	// Act
+    	// A final computed directory like "html" has no parent.
+    	Boolean absolute = parser.isDirectoryAbsolute(workspace, "html");
+    	
+    	// Assert
+    	Assert.assertFalse("When no parent is in the path, it is not absolute.", absolute);
+    }
 }


### PR DESCRIPTION
In the getDoxygenGeneratedDir method, when the final generated doxygen directory does not have a parent (e.g. "html"), getParentFile returns null and this causes an NPE because the null is then acted on by a call to exists(). I added a guard to prevent this NPE from occurring.
