### PR TITLE
Fix warnings count

### DIFF
--- a/src/main/java/hudson/plugins/doxygen/DoxygenWarningNote.java
+++ b/src/main/java/hudson/plugins/doxygen/DoxygenWarningNote.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
  */
 public class DoxygenWarningNote  extends ConsoleNote {
     /** Pattern to identify doxygen warning message */
-    public static Pattern PATTERN = Pattern.compile("^[Ww]arning:\\s.*");
+    public static Pattern PATTERN = Pattern.compile("^.*[Ww]arning:\\s.*");
     
     public DoxygenWarningNote() {
     }


### PR DESCRIPTION
With the new pattern, the following warning is catch and count.

`/var/lib/jenkins/home/workspace/lib2lgc_test/src/2lgc/net/strategy_connect_open_ssl.h:69: warning: Member ctx_ (variable) of class llgc::net::StrategyConnectOpenSsl is not documented.`

I do not have jdk so it's a not tested patch.